### PR TITLE
Add Wagtail 5.0 and Django 4.2 to test matrix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Framework :: Django',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 4',
+        'Framework :: Wagtail :: 5',
         'Operating System :: Unix',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ linting_folders=src/wagtailbakery/ tests/ examples/
 
 [tox]
 envlist=
-  py{38,39,310,311}-django{32,40,41}-wagtail{41,42} # Wagtail 4.1 LTS and 4.2 pre-release - all supported Python - all Django
+  py{38,39,310,311}-django{32,40,41}-wagtail{41,42} # Wagtail 4.1 LTS and 4.2 - all supported Python - all Django
+  py{38,39,310,311}-django{32,41,42}-wagtail50      # Wagtail 5.0 - all supported Python - all Django
   wagtailmain                                       # Wagtail main latest compatible version
 
 [testenv]
@@ -14,12 +15,13 @@ deps=
   django41: django>=4.1,<4.2
   wagtail41: wagtail>=4.1,<4.2  # Current LTS
   wagtail42: wagtail>=4.2,<5.0
+  wagtail50: wagtail>=5.0rc1,<5.1
 extras=test
 
 [testenv:wagtailmain]
 commands=py.test --cov=wagtailbakery --cov-report=xml {posargs}
 deps=
-  django>=4.1,<4.2
+  django>=4.2,<5
   git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 extras=test
 


### PR DESCRIPTION
I've created a new entry in the tox matrix for Wagtail 5 because it supports a different set of Django versions.

Also updated the `wagtailmain` entry to test against Django 4.2.