### PR TITLE
Use CircleCI Python 3.13 image for nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 jobs:
   nightly-wagtail-test:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.13
     steps:
       - checkout
       - run: git clone git@github.com:wagtail/wagtail.git


### PR DESCRIPTION
Wagtail main has dropped support for Python 3.8.